### PR TITLE
Remove unused variables

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -50,8 +50,8 @@ class AuthManager implements FactoryContract
     {
         $this->app = $app;
 
-        $this->userResolver = function ($guard = null) {
-            return $this->guard($guard)->user();
+        $this->userResolver = function () {
+            return $this->guard(null)->user();
         };
     }
 
@@ -197,8 +197,8 @@ class AuthManager implements FactoryContract
 
         $this->setDefaultDriver($name);
 
-        $this->userResolver = function ($name = null) {
-            return $this->guard($name)->user();
+        $this->userResolver = function () {
+            return $this->guard(null)->user();
         };
     }
 


### PR DESCRIPTION
I have found some unused variables within `AuthManager.php`.  I think it looks cleaner with just `null` rather than `$var = null`.

Cheers